### PR TITLE
Fixed args and kwargs on _build_job

### DIFF
--- a/sqjobs/worker.py
+++ b/sqjobs/worker.py
@@ -64,8 +64,10 @@ class Worker(object):
         job.retries = payload['_metadata']['retries']
         job.created_on = payload['_metadata']['created_on']
         job.first_execution_on = payload['_metadata']['first_execution_on']
+        args = payload['args'] or []
+        kwargs = payload['kwargs'] or {}
 
-        return job, payload['args'], payload['kwargs']
+        return job, args, kwargs
 
     def _change_retry_time(self, job):
         retry_time = job.next_retry()


### PR DESCRIPTION
When queuing a task without `kwargs` from a language such as PHP which doesn't differ from lists and dictionaries, the `kwargs` argument is encoded as a list, which throws this exception:

```
Traceback (most recent call last):
  File "/home/esteban/,venv/local/lib/python2.7/site-packages/sqjobs/worker.py", line 24, in execute
    job.run(*args, **kwargs)
TypeError: run() argument after ** must be a mapping, not list
```

This PR tries to fix it.