### PR TITLE
Added timeout parameter to broker jobs()

### DIFF
--- a/sqjobs/broker.py
+++ b/sqjobs/broker.py
@@ -18,11 +18,11 @@ class Broker(object):
         payload = self._gen_job_payload(job_class, args, kwargs)
         self.connector.enqueue(job_class.queue, payload)
 
-    def jobs(self, queue_name):
+    def jobs(self, queue_name, timeout=20):
         while True:
-            payload = self.connector.dequeue(queue_name)
+            payload = self.connector.dequeue(queue_name, wait_time=timeout)
 
-            if payload:
+            if payload or timeout == 0:
                 yield payload
 
     def delete_job(self, job):


### PR DESCRIPTION
Sometimes you may need to define the timeout when getting the jobs. In that case, you may need to return the yield as well, which will be `None` if no job could be unqueued.

I've done this because I needed to read all the available messages:

```Python
for job in broker.jobs(args[0], timeout=0):
    if job is None:
        # No more jobs
        break
    # do_something
```