### PR TITLE
Customize connection port

### DIFF
--- a/sqjobs/__init__.py
+++ b/sqjobs/__init__.py
@@ -2,7 +2,7 @@ from .job import Job
 from .metadata import __version__, __license__
 
 
-def create_sqs_broker(access_key, secret_key, region='us-west-1', is_secure=True):
+def create_sqs_broker(access_key, secret_key, region='us-west-1', is_secure=True, port=443):
     from .connectors.sqs import SQS
     from .broker import Broker
 
@@ -10,17 +10,18 @@ def create_sqs_broker(access_key, secret_key, region='us-west-1', is_secure=True
         access_key=access_key,
         secret_key=secret_key,
         region=region,
-        is_secure=is_secure
+        is_secure=is_secure,
+        port=port
     )
 
     broker = Broker(sqs)
     return broker
 
 
-def create_sqs_worker(queue_name, access_key, secret_key, region='us-west-1', is_secure=True):
+def create_sqs_worker(queue_name, access_key, secret_key, region='us-west-1', is_secure=True, port=443):
     from .worker import Worker
 
-    broker = create_sqs_broker(access_key, secret_key, region, is_secure)
+    broker = create_sqs_broker(access_key, secret_key, region, is_secure, port)
     worker = Worker(broker, queue_name)
 
     return worker

--- a/sqjobs/connectors/sqs.py
+++ b/sqjobs/connectors/sqs.py
@@ -23,6 +23,7 @@ class SQS(Connector):
         :param secret_key: secret key with access to SQS
         :param region: a valid region of AWS, like 'us-east-1'
         :param port: connection port, default to 443
+
         """
         self.access_key = access_key
         self.secret_key = secret_key

--- a/sqjobs/connectors/sqs.py
+++ b/sqjobs/connectors/sqs.py
@@ -37,7 +37,8 @@ class SQS(Connector):
         return 'SQS("{ak}", "{sk}", region="{region}", port="{port}")'.format(
             ak=self.access_key,
             sk="%s******%s" % (self.secret_key[0:6], self.secret_key[-4:]),
-            region=self.region
+            region=self.region,
+            port=self.port
         )
 
     @property

--- a/sqjobs/connectors/sqs.py
+++ b/sqjobs/connectors/sqs.py
@@ -15,23 +15,25 @@ class SQS(Connector):
     Manages a single connection to SQS
     """
 
-    def __init__(self, access_key, secret_key, region='us-east-1', is_secure=True):
+    def __init__(self, access_key, secret_key, region='us-east-1', is_secure=True, port=443):
         """
         Creates a new SQS object
 
         :param access_key: access key with access to SQS
         :param secret_key: secret key with access to SQS
         :param region: a valid region of AWS, like 'us-east-1'
+        :param port: connection port, default to 443
         """
         self.access_key = access_key
         self.secret_key = secret_key
         self.region = region
         self.is_secure = is_secure
+        self.port = port
 
         self._cached_connection = None
 
     def __repr__(self):
-        return 'SQS("{ak}", "{sk}", region="{region}")'.format(
+        return 'SQS("{ak}", "{sk}", region="{region}", port="{port}")'.format(
             ak=self.access_key,
             sk="%s******%s" % (self.secret_key[0:6], self.secret_key[-4:]),
             region=self.region
@@ -47,7 +49,8 @@ class SQS(Connector):
                 self.region,
                 aws_access_key_id=self.access_key,
                 aws_secret_access_key=self.secret_key,
-                is_secure=self.is_secure
+                is_secure=self.is_secure,
+                port=self.port
             )
 
             logger.debug('Created new SQS connection')

--- a/sqjobs/contrib/django/djsqjobs/management/commands/sqjobs.py
+++ b/sqjobs/contrib/django/djsqjobs/management/commands/sqjobs.py
@@ -24,7 +24,8 @@ class Command(BaseCommand):
             access_key=settings.SQJOBS_SQS_ACCESS_KEY,
             secret_key=settings.SQJOBS_SQS_SECRET_KEY,
             region=settings.SQJOBS_SQS_REGION,
-            is_secure=getattr(settings, 'SQJOBS_SQS_IS_SECURE', True)
+            is_secure=getattr(settings, 'SQJOBS_SQS_IS_SECURE', True),
+            port=getattr(settings, 'SQJOBS_SQS_CONNECTION_PORT', 443),
         )
 
         register_all_jobs(worker)

--- a/sqjobs/tests/helpers_test.py
+++ b/sqjobs/tests/helpers_test.py
@@ -15,6 +15,7 @@ class TestBuilders(object):
         assert broker.connector.access_key == 'access'
         assert broker.connector.secret_key == 'secret'
         assert broker.connector.region == 'us-west-1'
+        assert broker.connector.port == 443
 
     def test_worker_builder(self):
         worker = create_sqs_worker('queue_name', 'access', 'secret')
@@ -27,3 +28,4 @@ class TestBuilders(object):
         assert worker.broker.connector.access_key == 'access'
         assert worker.broker.connector.secret_key == 'secret'
         assert worker.broker.connector.region == 'us-west-1'
+        assert worker.broker.connector.port == 443


### PR DESCRIPTION
If you are using something like elasticmq or fakesqs in development, you have to be able to change the connection port
It uses 443 as default port, because aws uses ssl. 