### PR TITLE
Added delete_message to broker so it can manage not only jobs

### DIFF
--- a/sqjobs/broker.py
+++ b/sqjobs/broker.py
@@ -32,7 +32,10 @@ class Broker(object):
         return self.connector.get_dead_letter_queues()
 
     def delete_job(self, job):
-        self.connector.delete(job.queue, job.id)
+        self.delete_message(job.queue, job.id)
+
+    def delete_message(self, queue, message_id):
+        self.connector.delete(queue, message_id)
 
     def set_retry_time(self, job, delay):
         self.connector.set_retry_time(job.queue, job.id, delay)


### PR DESCRIPTION
Maybe sometimes you need to delete other things than a job, maybe some garbage message or a message from a dead letter queue.