### PR TITLE
Added option to extend lock read timeout

### DIFF
--- a/sqjobs/broker.py
+++ b/sqjobs/broker.py
@@ -40,8 +40,8 @@ class Broker(object):
         In the retry case the lock time is used to hide the message until the
         retry time passed and other worker use it to retry the job
         """
-        if job.retry_time:
-            self.connector.set_retry_time(job.queue, job.id, job.retry_time)
+        if job.lock_time:
+            self.connector.set_retry_time(job.queue, job.id, job.lock_time)
 
     def delete_job(self, job):
         self.delete_message(job.queue, job.id)

--- a/sqjobs/broker.py
+++ b/sqjobs/broker.py
@@ -31,6 +31,18 @@ class Broker(object):
     def dead_letter_queues(self):
         return self.connector.get_dead_letter_queues()
 
+    def change_message_lock_timeout(self, job):
+        """
+        Lock timeout uses the same amount of time than retry but with different
+        purposes.
+        Lock read timeout is used to extend the time the message is locked because
+        for example the job duration is beyond the default lock value.
+        In the retry case the lock time is used to hide the message until the
+        retry time passed and other worker use it to retry the job
+        """
+        if job.retry_time:
+            self.connector.set_retry_time(job.queue, job.id, job.retry_time)
+
     def delete_job(self, job):
         self.delete_message(job.queue, job.id)
 

--- a/sqjobs/job.py
+++ b/sqjobs/job.py
@@ -6,7 +6,16 @@ from six import add_metaclass
 class Job(object):
     name = None
     queue = 'sqjobs'
+    """
+    Time used to defined how many time the message will be locked until other
+    worker could retry the job
+    """
     retry_time = None  # None means use queue's default value
+    """
+    Define the time a message will be locked while the message is being consumed
+    to avoid other workers consume and execute the same job at the same time
+    """
+    lock_time = None  # None means use queue's default value
 
     def __init__(self):
         self.id = None

--- a/sqjobs/worker.py
+++ b/sqjobs/worker.py
@@ -30,6 +30,7 @@ class Worker(object):
             job, args, kwargs = self._build_job(payload)
 
             try:
+                self.broker.change_message_lock_timeout(job)
                 job.run(*args, **kwargs)
                 self.broker.delete_job(job)
                 job.on_success(*args, **kwargs)


### PR DESCRIPTION
This PR add a new variable to extend the lock mode for a message when a Job need more time to execute than the default established in the queue.