### PR TITLE
Support for abstract jobs

### DIFF
--- a/sqjobs/job.py
+++ b/sqjobs/job.py
@@ -5,6 +5,11 @@ from six import add_metaclass
 @add_metaclass(ABCMeta)
 class Job(object):
     name = None
+    """
+    Set this property to `True` if you define a base class in your application
+    that will be inherited for the real jobs you want.
+    """
+    abstract = False
     queue = 'sqjobs'
     """
     Time used to define how much time the message will be locked until other

--- a/sqjobs/tests/fixtures.py
+++ b/sqjobs/tests/fixtures.py
@@ -14,6 +14,10 @@ class FakeAdder(Adder):
     retry_time = None
 
 
+class AbstractAdder(Adder):
+    abstract = True
+
+
 class ComplexRetryJob(Adder):
     name = 'complex'
     retry_time = 10

--- a/sqjobs/tests/worker_test.py
+++ b/sqjobs/tests/worker_test.py
@@ -3,7 +3,7 @@ import pytest
 from ..connectors.dummy import Dummy
 from ..worker import Worker
 from ..broker import Broker
-from .fixtures import Adder, FakeAdder
+from .fixtures import Adder, FakeAdder, AbstractAdder
 
 
 class TestWorker(object):
@@ -26,6 +26,12 @@ class TestWorker(object):
 
         assert len(worker.registered_jobs) == 1
         assert worker.registered_jobs[Adder.name] == Adder
+
+    def test_register_abstract_job(self):
+        worker = Worker(self.broker, 'default')
+        worker.register_job(AbstractAdder)
+
+        assert len(worker.registered_jobs) == 0
 
     def test_register_job_twice(self):
         worker = Worker(self.broker, 'default')

--- a/sqjobs/worker.py
+++ b/sqjobs/worker.py
@@ -23,6 +23,9 @@ class Worker(object):
         if name in self.registered_jobs:
             logger.warning('Job %s already registered', name)
 
+        if job_class.abstract:
+            return
+
         self.registered_jobs[name] = job_class
 
     def execute(self):


### PR DESCRIPTION
I wanted to create a base job in my app with common functions such as `on_success` and `on_failure` but I don't want it to be registered as a job. I added a new `abstract` property and implemented that behaviour.