### PR TITLE
Compatibility with django 1.8

### DIFF
--- a/sqjobs/contrib/django/djsqjobs/management/commands/sqjobs.py
+++ b/sqjobs/contrib/django/djsqjobs/management/commands/sqjobs.py
@@ -11,6 +11,7 @@ from sqjobs.contrib.django.djsqjobs.beat import Beat
 
 class Command(BaseCommand):
     help = 'sqjobs commands'
+    args = True
 
     def handle(self, *args, **options):
         if args[0] == 'worker':


### PR DESCRIPTION
Django 1.8 compatibility change (https://docs.djangoproject.com/en/1.8/releases/1.8/#management-commands-that-only-accept-positional-arguments)