### PR TITLE
Job_id is optional, Reraise exceptions in eager mode

### DIFF
--- a/sqjobs/brokers/eager.py
+++ b/sqjobs/brokers/eager.py
@@ -1,3 +1,6 @@
+import sys
+import six
+
 from uuid import uuid4
 
 from .base import Broker
@@ -18,5 +21,6 @@ class Eager(Broker):
             eager_job.on_success(*args, **kwargs)
         except Exception as e:
             eager_job.on_failure(e, *args, **kwargs)
+            six.reraise(*sys.exc_info())
 
         return job_id, eager_job

--- a/sqjobs/tests/broker_test.py
+++ b/sqjobs/tests/broker_test.py
@@ -50,7 +50,8 @@ class TestBroker(object):
 
     def test_eager_failure(self):
         broker = Eager()
-        assert broker.add_job(Divider, 2, 0)[1].err == "ZeroDivisionError"
+        with pytest.raises(ZeroDivisionError):
+            assert broker.add_job(Divider, 2, 0)[1].err == "ZeroDivisionError"
 
     def test_payload_kwargs(self):
         broker = StandardBroker(self.connector)

--- a/sqjobs/worker.py
+++ b/sqjobs/worker.py
@@ -73,7 +73,11 @@ class Worker(object):
 
         job = job_class()
 
-        job.id = payload['job_id']
+        if 'job_id' in payload:
+            job.id = payload['job_id']
+        else:
+            job.id = payload['_metadata']['id']
+
         job.queue = self.queue_name
         job.broker_id = payload['_metadata']['id']
         job.retries = payload['_metadata']['retries']


### PR DESCRIPTION
- If job_id is not provided by the broker, it shouldn't break the worker
- Reraise exceptions in eager mode