### PR TITLE
Multiqueue worker

### DIFF
--- a/sqjobs/brokers/base.py
+++ b/sqjobs/brokers/base.py
@@ -34,12 +34,11 @@ class Broker(object):
         """
         return self.connector.serialize_job(job_name, job_id, args, kwargs)
 
-    def unserialize_job(self, job_class, queue_name, payload):
+    def unserialize_job(self, job_class, payload):
         """
         Build a job given a payload returned from the broker
 
         :param job_class: python class of the payload job
-        :param queue_name: queue where the job was located
         :param payload: python dict with the job arguments
         """
-        return self.connector.unserialize_job(job_class, queue_name, payload)
+        return self.connector.unserialize_job(job_class, payload)

--- a/sqjobs/brokers/multiqueue.py
+++ b/sqjobs/brokers/multiqueue.py
@@ -1,6 +1,4 @@
-from time import time
-from itertools import cycle
-from collections import defaultdict
+from time import time, sleep
 
 from .standard import Standard
 
@@ -18,19 +16,25 @@ class MultiQueue(Standard):
         * queue_names: List of queue names from where to read.
         * timeout: Not used by this implementation. It's kept for compatibility.
         """
-        queue_last_check = defaultdict(int)
+        queue_last_check = {queue: 0 for queue in queue_names}
 
         # loop through the queue list forever
-        for queue_name in cycle(queue_names):
-            next_check = queue_last_check[queue_name] + self.polling_interval
+        while True:
+            for queue in queue_names:
+                next_check = queue_last_check[queue] + self.polling_interval
 
-            if next_check > int(time()):
-                continue
+                # if it's been less than `polling_time` since last check, continue
+                if next_check > int(time()):
+                    continue
 
-            # wait_time needs to be 0 or it will block in the first queue
-            payload = self.connector.dequeue(queue_name, wait_time=0)
-            if payload:
-                yield payload
-            else:
-                # only update last check when queue is empty
-                queue_last_check[queue_name] = int(time())
+                # wait_time needs to be 0 or it will block in the first queue
+                payload = self.connector.dequeue(queue, wait_time=0)
+                if payload:
+                    queue_last_check[queue] = 0
+                    yield payload
+                else:
+                    queue_last_check[queue] = int(time())
+
+            # only sleep if all queues are empty
+            if all(value != 0 for value in queue_last_check.values()):
+                sleep(self.polling_interval)

--- a/sqjobs/brokers/multiqueue.py
+++ b/sqjobs/brokers/multiqueue.py
@@ -1,4 +1,4 @@
-from time import time, sleep
+from time import time
 from itertools import cycle
 from collections import defaultdict
 
@@ -25,7 +25,7 @@ class MultiQueue(Standard):
             next_check = queue_last_check[queue_name] + self.polling_interval
 
             if next_check > int(time()):
-                sleep(next_check - int(time()))
+                continue
 
             # wait_time needs to be 0 or it will block in the first queue
             payload = self.connector.dequeue(queue_name, wait_time=0)

--- a/sqjobs/brokers/multiqueue.py
+++ b/sqjobs/brokers/multiqueue.py
@@ -34,4 +34,3 @@ class MultiQueue(Standard):
             else:
                 # only update last check when queue is empty
                 queue_last_check[queue_name] = int(time())
-                break

--- a/sqjobs/brokers/multiqueue.py
+++ b/sqjobs/brokers/multiqueue.py
@@ -1,23 +1,35 @@
+from time import time, sleep
 from itertools import cycle
+from collections import defaultdict
 
 from .standard import Standard
-from ..job import Job, JobResult
 
 
 class MultiQueue(Standard):
     """
     Broker to execute jobs in an asynchronous way from multiple queues
     """
+    polling_interval = 20  # seconds
+
     def jobs(self, queue_names, timeout=0):
         """
         * queue_names: List of queue names from where to read.
         * timeout: Not used by this implementation. It's kept for compatibility.
         """
+        queue_last_check = defaultdict(int)
+
         for queue_name in cycle(queue_names):
+            next_check = queue_last_check[queue_name] + self.polling_interval
+
+            if next_check > int(time()):
+                sleep(next_check - int(time()))
+
             while True:
-                # wait_time needs to be 0 or it will block on the first queue
+                # wait_time needs to be 0 or it will block in the first queue
                 payload = self.connector.dequeue(queue_name, wait_time=0)
                 if payload:
                     yield payload
                 else:
                     break
+
+            queue_last_check[queue_name] = int(time())

--- a/sqjobs/brokers/multiqueue.py
+++ b/sqjobs/brokers/multiqueue.py
@@ -8,11 +8,11 @@ class MultiQueue(Standard):
     """
     Broker to execute jobs in an asynchronous way from multiple queues
     """
-    def jobs(self, queue_names, timeout=20):
+    def jobs(self, queue_names, timeout=0):
         for queue_name in cycle(queue_names):
             while True:
-                payload = self.connector.dequeue(queue_name, wait_time=timeout)
-                if payload or not timeout:
+                payload = self.connector.dequeue(queue_name, wait_time=0)
+                if payload:
                     yield payload
                 else:
                     break

--- a/sqjobs/brokers/multiqueue.py
+++ b/sqjobs/brokers/multiqueue.py
@@ -1,0 +1,18 @@
+from itertools import cycle
+
+from .standard import Standard
+from ..job import Job, JobResult
+
+
+class MultiQueue(Standard):
+    """
+    Broker to execute jobs in an asynchronous way from multiple queues
+    """
+    def jobs(self, queue_names, timeout=20):
+        for queue_name in cycle(queue_names):
+            while True:
+                payload = self.connector.dequeue(queue_name, wait_time=timeout)
+                if payload or not timeout:
+                    yield payload
+                else:
+                    break

--- a/sqjobs/brokers/multiqueue.py
+++ b/sqjobs/brokers/multiqueue.py
@@ -9,8 +9,13 @@ class MultiQueue(Standard):
     Broker to execute jobs in an asynchronous way from multiple queues
     """
     def jobs(self, queue_names, timeout=0):
+        """
+        * queue_names: List of queue names from where to read.
+        * timeout: Not used by this implementation. It's kept for compatibility.
+        """
         for queue_name in cycle(queue_names):
             while True:
+                # wait_time needs to be 0 or it will block on the first queue
                 payload = self.connector.dequeue(queue_name, wait_time=0)
                 if payload:
                     yield payload

--- a/sqjobs/connectors/base.py
+++ b/sqjobs/connectors/base.py
@@ -63,12 +63,11 @@ class Connector(object):
         raise NotImplementedError
 
     @abstractmethod
-    def unserialize_job(self, job_class, queue_name, payload):
+    def unserialize_job(self, job_class, payload):
         """
         Build a job given a payload returned from the connector
 
         :param job_class: Python class of the payload job
-        :param queue_name: queue where the job was located
         :param payload: Python dict with the job arguments
         """
         raise NotImplementedError

--- a/sqjobs/connectors/dummy.py
+++ b/sqjobs/connectors/dummy.py
@@ -46,11 +46,11 @@ class Dummy(Connector):
             'kwargs': kwargs
         }
 
-    def unserialize_job(self, job_class, queue_name, payload):
+    def unserialize_job(self, job_class, payload):
         job = job_class()
 
         job.id = payload['id']
-        job.queue_name = queue_name
+        job.queue_name = payload['_metadata']['queue_name']
         job.broker_id = payload['_metadata']['id']
         job.retries = payload['_metadata']['retries']
         job.created_on = payload['_metadata']['created_on']

--- a/sqjobs/tests/connector_test.py
+++ b/sqjobs/tests/connector_test.py
@@ -165,7 +165,8 @@ class TestSQSConnector(object):
             '_metadata': {
                 'created_on': datetime(2016, 4, 9, 7, 16, 44, tzinfo=timezone('UTC')),
                 'id': '1',
-                'retries': 0
+                'retries': 0,
+                'queue_name': 'my_queue'
             },
             'args': [1, 'second_arg'],
             'kwargs': {
@@ -210,7 +211,8 @@ class TestSQSConnector(object):
             '_metadata': {
                 'created_on': datetime(2016, 4, 9, 7, 16, 44, tzinfo=timezone('UTC')),
                 'id': '1',
-                'retries': 0
+                'retries': 0,
+                'queue_name': 'my_queue'
             },
             'key': 'value'
         }

--- a/sqjobs/tests/connector_test.py
+++ b/sqjobs/tests/connector_test.py
@@ -40,7 +40,7 @@ class TestConnectorInterface(object):
             Connector.serialize_job(dummy, dummy, 'job_id', 'args', {})
 
         with pytest.raises(NotImplementedError):
-            Connector.unserialize_job(dummy, dummy, 'demo', 'payload')
+            Connector.unserialize_job(dummy, dummy, 'payload')
 
 
 class SQSMock(object):
@@ -176,7 +176,6 @@ class TestSQSConnector(object):
 
         job, args, kwargs = sqs_connector.unserialize_job(
             job_class=Adder,
-            queue_name=QUEUE_NAME,
             payload=payload
         )
 

--- a/sqjobs/tests/utils_test.py
+++ b/sqjobs/tests/utils_test.py
@@ -1,9 +1,11 @@
 from sqjobs import metadata
 from sqjobs.brokers.eager import Eager
 from sqjobs.brokers.standard import Standard
+from sqjobs.brokers.multiqueue import MultiQueue
 from sqjobs.connectors.sqs import SQS
 from sqjobs.utils import (
-    create_sqs_broker, create_sqs_worker, get_jobs_from_module, create_eager_broker
+    create_sqs_broker, create_sqs_worker, get_jobs_from_module,
+    create_eager_broker, create_multiqueue_sqs_worker
 )
 from sqjobs.worker import Worker
 from .fixtures import Adder, AbstractAdder
@@ -37,6 +39,18 @@ class TestBuilders(object):
         assert isinstance(worker.broker.connector, SQS)
 
         assert worker.queue_name == 'queue_name'
+        assert worker.broker.connector.access_key == 'access'
+        assert worker.broker.connector.secret_key == 'secret'
+        assert worker.broker.connector.region_name == 'us-west-1'
+
+    def test_multiqueue_worker_builder(self):
+        worker = create_multiqueue_sqs_worker(['queue_name'], 'access', 'secret')
+
+        assert isinstance(worker, Worker)
+        assert isinstance(worker.broker, MultiQueue)
+        assert isinstance(worker.broker.connector, SQS)
+
+        assert worker.queue_name == ['queue_name']
         assert worker.broker.connector.access_key == 'access'
         assert worker.broker.connector.secret_key == 'secret'
         assert worker.broker.connector.region_name == 'us-west-1'

--- a/sqjobs/utils.py
+++ b/sqjobs/utils.py
@@ -3,6 +3,7 @@ import inspect
 
 from .job import Job
 from .brokers.standard import Standard
+from .brokers.multiqueue import MultiQueue
 from .brokers.eager import Eager
 from .connectors.sqs import SQS
 from .worker import Worker
@@ -29,6 +30,16 @@ def create_sqs_broker(access_key, secret_key, region_name='us-west-1', endpoint_
 def create_sqs_worker(queue_name, access_key, secret_key, region_name='us-west-1', endpoint_url=None):
     broker = create_sqs_broker(access_key, secret_key, region_name, endpoint_url)
     return Worker(broker, queue_name)
+
+
+def create_multiqueue_sqs_worker(queue_names, access_key, secret_key, region_name='us-west-1', endpoint_url=None):
+    sqs = SQS(
+        access_key=access_key,
+        secret_key=secret_key,
+        region_name=region_name,
+        endpoint_url=endpoint_url,
+    )
+    return Worker(MultiQueue(sqs), queue_names)
 
 
 def get_jobs_from_module(module_name):

--- a/sqjobs/worker.py
+++ b/sqjobs/worker.py
@@ -51,7 +51,6 @@ class Worker(object):
                     continue
 
                 job, args, kwargs = self.broker.unserialize_job(job_class, payload)
-                self._set_custom_retry_time_if_needed(job)
                 self._execute_job(job, args, kwargs)
             except:
                 logger.exception('Error executing job')
@@ -68,10 +67,12 @@ class Worker(object):
             self.broker.delete_job(job)
         except RetryException:
             job.on_retry()
+            self._set_custom_retry_time_if_needed(job)
             return
         except:
             job.on_failure()
             self._handle_exception(job, args, kwargs, *sys.exc_info())
+            self._set_custom_retry_time_if_needed(job)
             return
 
         job.on_success()

--- a/sqjobs/worker.py
+++ b/sqjobs/worker.py
@@ -51,6 +51,7 @@ class Worker(object):
                     continue
 
                 job, args, kwargs = self.broker.unserialize_job(job_class, payload)
+                self._set_custom_retry_time_if_needed(job)
                 self._execute_job(job, args, kwargs)
             except:
                 logger.exception('Error executing job')

--- a/sqjobs/worker.py
+++ b/sqjobs/worker.py
@@ -50,7 +50,7 @@ class Worker(object):
                     logger.error('Unregistered task: %s', payload['name'])
                     continue
 
-                job, args, kwargs = self.broker.unserialize_job(job_class, self.queue_name, payload)
+                job, args, kwargs = self.broker.unserialize_job(job_class, payload)
                 self._set_custom_retry_time_if_needed(job)
                 self._execute_job(job, args, kwargs)
             except:


### PR DESCRIPTION
I created a new broker that allows the same worker to read from a list of queues.

I also added a new util to create the multiqueue worker. Only to create the worker and not a multiqueue broker because there is no use for that.

When unserializing the job, now we get the queue from the job metadata instead of the worker, as said worker could have many queues.