### PR TITLE
Change visibility timeout after the task has failed

### DIFF
--- a/sqjobs/worker.py
+++ b/sqjobs/worker.py
@@ -51,7 +51,6 @@ class Worker(object):
                     continue
 
                 job, args, kwargs = self.broker.unserialize_job(job_class, self.queue_name, payload)
-                self._set_custom_retry_time_if_needed(job)
                 self._execute_job(job, args, kwargs)
             except:
                 logger.exception('Error executing job')
@@ -68,10 +67,12 @@ class Worker(object):
             self.broker.delete_job(job)
         except RetryException:
             job.on_retry()
+            self._set_custom_retry_time_if_needed(job)
             return
         except:
             job.on_failure()
             self._handle_exception(job, args, kwargs, *sys.exc_info())
+            self._set_custom_retry_time_if_needed(job)
             return
 
         job.on_success()

--- a/sqjobs/worker.py
+++ b/sqjobs/worker.py
@@ -51,6 +51,7 @@ class Worker(object):
                     continue
 
                 job, args, kwargs = self.broker.unserialize_job(job_class, self.queue_name, payload)
+                self._set_custom_retry_time_if_needed(job)
                 self._execute_job(job, args, kwargs)
             except:
                 logger.exception('Error executing job')


### PR DESCRIPTION
In the way that this is done now;
Let's say that I define `job.retry_time = 30`, so SQJobs sets the visibility timeout of the message to 30 seconds.
Then the task is executed and, if it runs for 30 seconds or more and fails, it will be executed again right away because the 30 seconds have already passed.

This PR changes the location of `_set_custom_retry_time_if_needed` so that it's executed after the task has failed and the `retry_time` set in the job is the real time that the worker "waits" before executing the same task again.